### PR TITLE
feat(Run): add ability to kick off MCP via docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,85 @@
+# Dependencies
+node_modules/
+npm-debug.log*
+pnpm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Testing
+test/
+coverage/
+*.test.js
+*.test.ts
+*.spec.js
+*.spec.ts
+
+# Build artifacts (handled by multi-stage build)
+dist/
+
+# Development files
+.env
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+# IDE and editor files
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# OS generated files
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+
+# Git
+.git/
+.gitignore
+
+# Documentation (not needed in container)
+README.md
+CLAUDE.md
+*.md
+
+# CI/CD files
+.github/
+.dockerignore
+Dockerfile*
+
+# Temporary files
+tmp/
+temp/
+*.tmp
+*.log
+
+# Docker compose files (not needed in container)
+docker-compose*.yml
+docker-compose*.yaml
+
+# Package manager files
+.pnpm-store/
+.yarn/
+.npm/
+package-lock.json
+yarn.lock
+
+# ESLint and Prettier
+.eslintrc*
+.prettierrc*
+eslint.config.js
+
+# TypeScript config is needed for build stage
+# tsconfig.json
+
+# Vitest config
+vitest.config.ts
+
+# Smithery config (handled separately)
+smithery.yaml

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,130 @@
+name: Docker Build and Publish
+
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build Docker image (test)
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64
+          push: false
+          tags: test-image:latest
+          labels: ${{ steps.meta.outputs.labels }}
+          load: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Test Docker image
+        run: |
+          echo "Testing Docker image startup..."
+          docker run --rm -d --name test-container \
+            -e GOOGLE_CLOUD_PROJECT=test-project \
+            -e LAZY_AUTH=true \
+            test-image:latest || true
+          
+          sleep 5
+          
+          echo "Checking container logs..."
+          docker logs test-container || true
+          
+          echo "Checking if container is running as non-root user..."
+          docker exec test-container whoami | grep -q nodejs
+          
+          echo "Stopping test container..."
+          docker stop test-container || true
+          
+          echo "✅ Docker image tests passed"
+
+      - name: Build and push Docker image
+        if: github.event_name != 'pull_request'
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Generate image summary
+        if: github.event_name != 'pull_request'
+        run: |
+          echo "## Docker Image Published 🐳" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Image:** \`${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Tags:**" >> $GITHUB_STEP_SUMMARY
+          echo "${{ steps.meta.outputs.tags }}" | sed 's/^/- `/' | sed 's/$/`/' >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Usage:**" >> $GITHUB_STEP_SUMMARY
+          echo '```bash' >> $GITHUB_STEP_SUMMARY
+          echo "docker run --rm -e GOOGLE_CLOUD_PROJECT=your-project \\" >> $GITHUB_STEP_SUMMARY
+          echo "  -v ~/.config/gcloud/application_default_credentials.json:/app/credentials/key.json:ro \\" >> $GITHUB_STEP_SUMMARY
+          echo "  -e GOOGLE_APPLICATION_CREDENTIALS=/app/credentials/key.json \\" >> $GITHUB_STEP_SUMMARY
+          echo "  ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+
+  security-scan:
+    runs-on: ubuntu-latest
+    needs: build-and-test
+    if: github.event_name != 'pull_request'
+    permissions:
+      contents: read
+      packages: read
+      security-events: write
+
+    steps:
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v2
+        if: always()
+        with:
+          sarif_file: 'trivy-results.sarif'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,71 @@
-FROM node:22-alpine
+# Multi-stage build for Google Cloud MCP Server
+FROM node:22-alpine AS base
 
+# Install pnpm globally
+RUN npm install -g pnpm@9.15.4
+
+# Set working directory
 WORKDIR /app
 
 # Copy package files
 COPY package.json pnpm-lock.yaml ./
 
-# Install pnpm
-RUN npm install -g pnpm
-
 # Install dependencies
-RUN pnpm install
+RUN pnpm install --frozen-lockfile
 
-# Copy application code
+# Development stage
+FROM base AS development
+COPY . .
+CMD ["pnpm", "dev"]
+
+# Build stage
+FROM base AS build
+
+# Copy source code
 COPY . .
 
 # Build the application
 RUN pnpm build
 
-# Command will be provided by smithery.yaml
+# Production stage
+FROM node:22-alpine AS production
+
+# Add labels for better container management
+LABEL org.opencontainers.image.title="Google Cloud MCP Server"
+LABEL org.opencontainers.image.description="Model Context Protocol server for Google Cloud services"
+LABEL org.opencontainers.image.version="0.4.0"
+LABEL org.opencontainers.image.authors="Kristof Kowalski <k@ko.wal.ski>"
+LABEL org.opencontainers.image.source="https://github.com/krzko/google-cloud-mcp"
+LABEL org.opencontainers.image.licenses="Apache"
+
+# Create non-root user for security
+RUN addgroup -g 1001 -S nodejs && \
+    adduser -S nodejs -u 1001
+
+# Set working directory
+WORKDIR /app
+
+# Copy built application from build stage
+COPY --from=build --chown=nodejs:nodejs /app/dist ./dist
+COPY --from=build --chown=nodejs:nodejs /app/package.json ./package.json
+COPY --from=build --chown=nodejs:nodejs /app/pnpm-lock.yaml ./pnpm-lock.yaml
+
+# Install only production dependencies
+RUN npm install -g pnpm@9.15.4 && \
+    pnpm install --prod --frozen-lockfile && \
+    pnpm store prune && \
+    npm uninstall -g pnpm && \
+    rm -rf /root/.npm /root/.pnpm-store ./pnpm-lock.yaml
+
+# Switch to non-root user
+USER nodejs
+
+# Expose port (though MCP uses stdio, this is for future extensions)
+EXPOSE 3000
+
+# Add health check
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+    CMD node -e "console.log('Health check passed')" || exit 1
+
+# Default command
 CMD ["node", "dist/index.js"]

--- a/README.md
+++ b/README.md
@@ -94,6 +94,37 @@ The server will also use the `GOOGLE_CLOUD_PROJECT` environment variable if set,
 
 ## Installation
 
+### Option 1: Using Docker (Recommended)
+
+The easiest way to run this MCP server is using Docker. Ensure you have your
+application default credentials set up with the Google Cloud SDK before doing
+this.
+```bash
+# Set your project ID
+gcloud auth application-default login
+```
+
+**Configure your MCP client to use the Docker container:**
+
+```json
+{
+  "mcpServers": {
+    "google-cloud-mcp": {
+      "command": "docker",
+      "args": [
+        "run", "--rm", "-i",
+        "-e", "GOOGLE_CLOUD_PROJECT=your-project-id",
+        "-v", "/Users/foo/.config/gcloud/application_default_credentials.json:/app/credentials/key.json:ro",
+        "-e", "GOOGLE_APPLICATION_CREDENTIALS=/app/credentials/key.json",
+        "ghcr.io/krzko/google-cloud-mcp:latest"
+      ]
+    }
+  }
+}
+```
+
+### Option 2: Local Installation
+
 ```bash
 # Clone the repository
 git clone https://github.com/krzko/google-cloud-mcp.git
@@ -128,6 +159,80 @@ Configure the `mcpServers` in your client:
       }
   }
 }
+```
+
+## Docker Usage
+
+### Quick Start
+
+```bash
+# Run with minimal configuration
+docker run --rm -e GOOGLE_CLOUD_PROJECT=your-project ghcr.io/krzko/google-cloud-mcp:latest
+
+# Run with debug logging
+docker run --rm \
+  -e GOOGLE_CLOUD_PROJECT=your-project \
+  -e DEBUG=true \
+  ghcr.io/krzko/google-cloud-mcp:latest
+```
+
+### Authentication Methods
+
+**Method 1: Service Account Key File (Recommended)**
+```bash
+docker run --rm \
+  -e GOOGLE_CLOUD_PROJECT=your-project \
+  -v /path/to/service-account-key.json:/app/credentials/key.json:ro \
+  -e GOOGLE_APPLICATION_CREDENTIALS=/app/credentials/key.json \
+  ghcr.io/krzko/google-cloud-mcp:latest
+```
+
+**Method 2: Environment Variables**
+```bash
+docker run --rm \
+  -e GOOGLE_CLOUD_PROJECT=your-project \
+  -e GOOGLE_CLIENT_EMAIL=your-service-account@project.iam.gserviceaccount.com \
+  -e GOOGLE_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\n..." \
+  ghcr.io/krzko/google-cloud-mcp:latest
+```
+
+**Method 3: Application Default Credentials**
+```bash
+docker run --rm \
+  -e GOOGLE_CLOUD_PROJECT=your-project \
+  -v ~/.config/gcloud/application_default_credentials.json:/app/credentials/key.json:ro \
+  -e GOOGLE_APPLICATION_CREDENTIALS=/app/credentials/key.json \
+  ghcr.io/krzko/google-cloud-mcp:latest
+```
+
+### Docker Compose
+
+Use the included `docker-compose.yml` for easier local development:
+
+```yaml
+# Set environment variables
+export GOOGLE_CLOUD_PROJECT=your-project-id
+export DEBUG=false
+
+# Run the production service
+docker-compose up google-cloud-mcp
+
+# Run the development service with live reload
+docker-compose --profile dev up google-cloud-mcp-dev
+```
+
+### Building Locally
+
+```bash
+# Build the Docker image
+docker build -t google-cloud-mcp .
+
+# Run your locally built image
+docker run --rm -e GOOGLE_CLOUD_PROJECT=your-project google-cloud-mcp
+
+# Build for development with live reload
+docker build --target development -t google-cloud-mcp:dev .
+docker run --rm -v $(pwd):/app -e GOOGLE_CLOUD_PROJECT=your-project google-cloud-mcp:dev
 ```
 
 ## Development


### PR DESCRIPTION
I noticed that the current process is to clone this repo and build it locally. It'd be nice if node and pnpm and such weren't requirements to use this, and I could just use docker! I've been testing it locally and it seems great, though not 100% sure that the github action is bullet proof.